### PR TITLE
Clean up jdt2famix.cmd

### DIFF
--- a/res/jdt2famix.cmd
+++ b/res/jdt2famix.cmd
@@ -1,12 +1,10 @@
 @echo off
 setLocal EnableDelayedExpansion
+
 set BASEPATH=%~dp0
-echo !BASEPATH!
-set CLASSPATH="!BASEPATH!
+set CLASSPATH=!BASEPATH!
 for %%a in (!BASEPATH!\*.jar) do (
    set CLASSPATH=!CLASSPATH!;%%a
- )
-set CLASSPATH=!CLASSPATH!"
-echo !CLASSPATH!
-java -cp !CLASSPATH! com.feenk.jdt2famix.injava.Main
- 
+)
+
+java -cp "!CLASSPATH!" com.feenk.jdt2famix.injava.Main

--- a/res/jdt2famix.cmd
+++ b/res/jdt2famix.cmd
@@ -7,4 +7,4 @@ for %%a in (!BASEPATH!\*.jar) do (
    set CLASSPATH=!CLASSPATH!;%%a
 )
 
-java -cp "!CLASSPATH!" com.feenk.jdt2famix.injava.Main
+java -cp "!CLASSPATH!" com.feenk.jdt2famix.injava.Main %*

--- a/res/jdt2famix.sh
+++ b/res/jdt2famix.sh
@@ -14,4 +14,4 @@ CYGWIN*)
   pathsep=";"
 esac
 
-exec java -cp "$basedir/*$pathsep$basedir" com.feenk.jdt2famix.injava.Main
+exec java -cp "$basedir/*$pathsep$basedir" com.feenk.jdt2famix.injava.Main "$@"


### PR DESCRIPTION
Dumping variable contents to stdout without any context is bad behavior.
In addition, these variables are not of interest to the jdt2famix user,
therefore they are no longer shown.

Having the unbalanced quotes one at the beginning of "set CLASSPATH" and
one on the last instance of "set CLASSPATH" was very confusing.