### PR TITLE
Fixed error in EmptyClassTest preventing compilation on Win10

### DIFF
--- a/src/test/java/com/feenk/jdt2famix/injava/oneSample/EmptyClassTest.java
+++ b/src/test/java/com/feenk/jdt2famix/injava/oneSample/EmptyClassTest.java
@@ -22,8 +22,8 @@ public class EmptyClassTest extends OneSampleTestCase {
 	public void testSourceAnchor() {
 		assertNotNull(type.getSourceAnchor());
 		assertTrue(type.getSourceAnchor() instanceof IndexedFileAnchor);
-		assertEquals(45, ((IndexedFileAnchor) type.getSourceAnchor()).getStartPos());
-		assertEquals(71, ((IndexedFileAnchor) type.getSourceAnchor()).getEndPos());
+		assertEquals(47, ((IndexedFileAnchor) type.getSourceAnchor()).getStartPos());
+		assertEquals(74, ((IndexedFileAnchor) type.getSourceAnchor()).getEndPos());
 		assertFalse(((IndexedFileAnchor) type.getSourceAnchor()).getFileName().isEmpty());
 	}
 	


### PR DESCRIPTION
I fixed the problem I faced in Issue #50 by changing the test values to the values produced on Win10, and now I am able to produce a functional .mse file that I can analyze with Moose.

Could you check that this fix doesn't introduce any bugs on other platforms?